### PR TITLE
adds ability to specify type

### DIFF
--- a/lib/ex_dwolla.ex
+++ b/lib/ex_dwolla.ex
@@ -303,7 +303,7 @@ defmodule ExDwolla.Customers do
   @type upload_document_request :: %{
           customer_id: String.t(),
           filename: String.t(),
-          path_or_binary: binary(),
+          path_or_binary: binary() | {:contents, binary()} | {:path, String.t()},
           document_type: String.t()
         }
 

--- a/lib/ex_dwolla/core.ex
+++ b/lib/ex_dwolla/core.ex
@@ -120,6 +120,12 @@ defmodule ExDwolla.Core do
     end
   end
 
+  defp get_file_content({:contents, file_contents}) when is_binary(file_contents),
+    do: {:ok, file_contents}
+
+  defp get_file_content({:path, file_path}) when is_binary(file_path),
+    do: File.read(file_path)
+
   defp get_file_content(file_path_or_binary) do
     case File.read(file_path_or_binary) do
       {:ok, content} -> {:ok, content}


### PR DESCRIPTION
this change allows the caller to specify the type of document by passing
in a tuple with the second value's type allowing the caller's document
to not be assumed but explicitly specified.
