### PR TITLE
adjusts create_transfer to Core.create_request

### DIFF
--- a/lib/ex_dwolla.ex
+++ b/lib/ex_dwolla.ex
@@ -391,7 +391,7 @@ defmodule ExDwolla.Transfers do
 
   @spec create(create_transfer_request(), String.t()) :: create_response()
   def create(%{} = transfer, idempotency_key),
-    do: Core.update_request("/transfers", transfer, [{"Idempotency-Key", idempotency_key}])
+    do: Core.create_request("/transfers", transfer, [{"Idempotency-Key", idempotency_key}])
 
   def simulate(),
     do: Core.update_request("/sandbox-simulations", "")


### PR DESCRIPTION
This should allow the transfer id for the new transfer to be returned to the caller which is very important. Which transfer id is returned is not straight forward.